### PR TITLE
Set working directory to /opt, rather than /opt/lib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /tmp
 RUN yumdownloader libffi libffi-devel cairo pango && rpmdev-extract *rpm
 
 RUN mkdir /opt/lib
-WORKDIR /opt/lib
+WORKDIR /opt
 RUN cp -P -R /tmp/*/usr/lib64/* /opt/lib
-RUN ln libpango-1.0.so.0 pango-1.0 && ln libpangocairo-1.0.so.0 pangocairo-1.0
+RUN ln lib/libpango-1.0.so.0 lib/pango-1.0 && ln lib/libpangocairo-1.0.so.0 lib/pangocairo-1.0
 RUN zip weasyprint_lambda_layer.zip lib/*


### PR DESCRIPTION
Current version sets working directory to /opt, the zip command is unable to find the libs directory. Changing the zip command dumps the zip file into /opt/lib, which breaks the instructions in the README. This feels like a nice compromise.